### PR TITLE
Add logic to strip prefix from api id/key

### DIFF
--- a/pre-request.js
+++ b/pre-request.js
@@ -29,13 +29,20 @@ function toHexBinary(input) {
     return CryptoJS.enc.Hex.stringify(CryptoJS.enc.Utf8.parse(input));
 }
 
+function removePrefixFromApiCredential(input) {
+    return input.split('-').at(-1);
+}
+
 function calculateVeracodeAuthHeader(httpMethod, requestUrl) {
+    const formattedId = removePrefixFromApiCredential(id);
+    const formattedKey = removePrefixFromApiCredential(key);
+
     let parsedUrl = url.parse(requestUrl);
-    let data = `id=${id}&host=${parsedUrl.hostname}&url=${parsedUrl.path}&method=${httpMethod}`;
+    let data = `id=${formattedId}&host=${parsedUrl.hostname}&url=${parsedUrl.path}&method=${httpMethod}`;
     let dateStamp = Date.now().toString();
     let nonceBytes = newNonce();
-    let dataSignature = calculateDataSignature(key, nonceBytes, dateStamp, data);
-    let authorizationParam = `id=${id},ts=${dateStamp},nonce=${toHexBinary(nonceBytes)},sig=${dataSignature}`;
+    let dataSignature = calculateDataSignature(formattedKey, nonceBytes, dateStamp, data);
+    let authorizationParam = `id=${formattedId},ts=${dateStamp},nonce=${toHexBinary(nonceBytes)},sig=${dataSignature}`;
     return authorizationScheme + " " + authorizationParam;
 }
 


### PR DESCRIPTION
In the python api signing library, we remove the prefix from API keys/ids and we are missing that logic here.
https://pypi.org/project/veracode-api-signing/22.3.0/#files

I don't use postman and this logic is being copied from the insomnia plugin changes. If you could test these before-hand that'd be great.

```yaml
API KEY: vera01fi-a778b87c8d8ef8e8c7e90e7ee1e2e3e5eca521
API_SECRET_KEY: vera01fs-812fedec1d1f23f23f32d123e3128f7ce7cea70c5b4ac5b5d5123a478b9e9a8c6e799c89ed8c7e87b8a862
```
should have the prefix stripped, and instead should be:
```yaml
API KEY: a778b87c8d8ef8e8c7e90e7ee1e2e3e5eca521
API_SECRET_KEY: 812fedec1d1f23f23f32d123e3128f7ce7cea70c5b4ac5b5d5123a478b9e9a8c6e799c89ed8c7e87b8a862
```