### PR TITLE
Update README.md to fix crecredentials typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you have not does so, please follow these steps to generate the necessary API
 
 ## Postman Example
 
-These instructions will help you quickly setup the Postman example provided by Vercode. The example provides all the necessary scripts, environments, variables and collection request examples to start using Postman against Vercode APIs.
+These instructions will help you quickly setup the Postman example provided by Veracode. The example provides all the necessary scripts, environments, variables and collection request examples to start using Postman against Veracode APIs.
 
 The content used for this example is located [here](https://github.com/veracode/veracode-postman/tree/main) The content consist of a Collection, Environment and pre-request script.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Using [Veracode APIs](https://docs.veracode.com/r/c_gettingstarted) with Postman
 If you have not does so, please follow these steps to generate the necessary API Token Credential to use with Postman. This will be required for providing the variables of *api_id* and *api_key*.
 
 1. [Generate API credentials](https://docs.veracode.com/r/t_create_api_creds) for your Veracode user.
-2. Store the credential information is  a safe place or as a cre[credential file](https://docs.veracode.com/r/c_configure_api_cred_file) for use with Veracode products.
+2. Store the credential information is  a safe place or as a [credential file](https://docs.veracode.com/r/c_configure_api_cred_file) for use with Veracode products.
 
 ## Postman Example
 


### PR DESCRIPTION
This change updates the README to fix two typos:
- `cre[credential file](...)` to `[credential file](...)`
- `Vercode` to `Veracode`